### PR TITLE
#12 Kill all mutations in Board.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,15 @@
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
                 <version>1.4.10</version>
+                <executions>
+                    <execution>
+                        <id>pit-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>mutationCoverage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/mdolat/gameoflife/roundsManager/ManagerTest.java
+++ b/src/test/java/com/mdolat/gameoflife/roundsManager/ManagerTest.java
@@ -1,5 +1,6 @@
 package com.mdolat.gameoflife.roundsManager;
 
+import com.mdolat.gameoflife.board.Board;
 import com.mdolat.gameoflife.roundsManager.strategies.ClassicConway;
 import com.mdolat.gameoflife.utils.BoardsManager;
 import org.junit.Before;
@@ -14,6 +15,14 @@ public class ManagerTest {
     @Before
     public void setUp(){
         this.roundCalculator = new RoundCalculator(new ClassicConway());
+    }
+
+    @Test
+    public void shouldVerifyBoards() {
+        Board boardOne = BoardsManager.getEmptyBoard();
+        Board boardTwo = null;
+        assertEquals(boardOne, boardOne);
+        assertNotEquals(boardOne, boardTwo);
     }
 
     @Test


### PR DESCRIPTION
Refers #12 

- Kill all mutations in Board.java

- Add the goal 'mutationCoverage' to the test phase, which would generate the PIT report every time we run "mvn clean test"